### PR TITLE
Name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ The goal is to setup a bunch of statuspages to monitor public facing va.gov webs
 ## Setup
 
 - Install [Wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update).
+
+## Deployment
+
+- [va.gov monitor](https://vagov-cf-statuspage.vagov-cf-statuspage.workers.dev/)

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The goal is to setup a bunch of statuspages to monitor public facing va.gov webs
 
 ## Deployment
 
-- [va.gov monitor](https://vagov-cf-statuspage.vagov-cf-statuspage.workers.dev/)
+- [va.gov monitor](https://monitor.vagov-cf-statuspage.workers.dev/)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "vagov-cf-statuspage"
+name = "monitor"
 workers_dev = true
 account_id = "41c979ec0c01c61c270c515c9b08fc59"
 type = "webpack"


### PR DESCRIPTION
- Updating URL to https://monitor.vagov-cf-statuspage.workers.dev/
- Updating documentation